### PR TITLE
fix: Resolve capability error `The current thread cannot access 'Insta……nce' (lacking capability plugin)`

### DIFF
--- a/Src/Utils/Sonner.luau
+++ b/Src/Utils/Sonner.luau
@@ -199,7 +199,6 @@ function Sonner.toast(text, internalTime)
 end
 
 function Sonner.promise(func, options)
-    setthreadidentity(8)
 	local loadingText = options.loadingText or "Loading..."
 	local successText = options.successText or "Success!"
 	local errorText = options.errorText or "Error!"
@@ -223,8 +222,8 @@ function Sonner.promise(func, options)
 		success, resultOrError = pcall(func) -- yes mstudio45, your famous pcall is better (- deivid)
 
 	   	task.spawn(function()
-			-- print(getthreadidentity()) --> 8
-
+			setthreadidentity(8)
+			
 			-- The thread identity is 8 when setting it on the parent thread (Sonner.promise), but it still lacks capabilities when running another child thread
 			-- Capabilities here should pass from a thread to another... Could be an upstream (executor) issue ?
 			

--- a/Src/Window.luau
+++ b/Src/Window.luau
@@ -1832,7 +1832,7 @@ CreateInfoDropdownButton("network", "Event", {
 				return
 			end
 
-			task.spawn(wax.shared.Sonner.promise, function()
+			wax.shared.Sonner.promise(function()
 				wax.shared.ReplayCallInfo(CurrentInfo, CurrentTab.Name)
 			end, {
 				loadingText = "Replaying event...",
@@ -3150,7 +3150,7 @@ function CreateCallFrame(CallInfo)
 						return
 					end
 
-					task.spawn(wax.shared.Sonner.promise, function()
+					wax.shared.Sonner.promise(function()
 						wax.shared.ReplayCallInfo(CallInfo, CurrentTab.Name)
 					end, {
 						loadingText = "Replaying event...",


### PR DESCRIPTION
In regards to https://github.com/notpoiu/cobalt/issues/3 and https://github.com/notpoiu/cobalt/issues/6

This is a very weird occurrence where thread identity won't pass to functions like `TweenService:Create` which shouldn't really happen (or atleast, I don't think it should)